### PR TITLE
Bumping version of sqllite 3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,7 +89,7 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (~> 2.8)
-    sqlite3 (1.3.8)
+    sqlite3 (1.3.10)
     thor (0.18.1)
     thread_safe (0.1.3)
       atomic


### PR DESCRIPTION
While working on forked alexsaveliev/srclib-ruby (Windows/Cygwin support) I have bumped version of Ruby used to 2.2.2 from 2.1.2 (to have version available on both Windows and Linux) and discovered that sqllite 1.3.8 does not work with Ruby 2.2.x (compilation fails) so I've updated sqllite to 1.3.10 in test case